### PR TITLE
Default include-all-places on and fix language select spacing on mobile

### DIFF
--- a/speciesdex.html
+++ b/speciesdex.html
@@ -57,8 +57,8 @@
       }
     }
     </script>
-    <link rel="stylesheet" href="styles.css?v=3" />
-    <link rel="stylesheet" href="dark-mode.css?v=3" />
+    <link rel="stylesheet" href="styles.css?v=4" />
+    <link rel="stylesheet" href="dark-mode.css?v=4" />
     <!-- Leaflet CSS -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
     <style>
@@ -605,6 +605,7 @@
               type="checkbox"
               id="includeAllPlacesCheckbox"
               class="include-all-places-checkbox"
+              checked
             />
             <label for="includeAllPlacesCheckbox"
               >Include my observations from all places</label

--- a/styles.css
+++ b/styles.css
@@ -898,6 +898,14 @@ input[type="checkbox"] {
     padding: 8px 10px;
   }
 
+  /* The language select wrapper is a span, so its vertical margins are
+     ignored while inline; make it a block to give the select breathing
+     room from the checkbox rows below */
+  .language-select-container {
+    display: block;
+    margin: 10px 0 16px;
+  }
+
   /* Keep each checkbox tight against its own label and put the wide
      gap between option groups instead, so ownership reads clearly */
   .advanced-options-checkbox {


### PR DESCRIPTION
## Changes

- **"Include my observations from all places" is now checked by default** — the script only reads the checkbox at search time, so the `checked` attribute is all that's needed.
- **Language select spacing on mobile**: the select's wrapper is an inline `span`, so the vertical margins it was given never applied and the checkbox rows sat ~2px below it. On mobile widths the wrapper is now a block with real margins, giving the select clear separation (measured 18px) from the checkboxes.
- Bumped the stylesheet version params so cached CSS refreshes.

## Testing

Verified in a real browser at 390px: checkbox reports `checked: true` on load, and the measured gap between the select and the first checkbox row is 18px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCN7BpBma5rdR4fdeDXfjh

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCN7BpBma5rdR4fdeDXfjh)_