### PR TITLE
Fix profile ID counts + add species status filter to lifelist and species observed

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -709,14 +709,16 @@ body.dark-mode .view-toggle .view-btn.active {
 
 /* Species-observed controls */
 body.dark-mode #iconicTaxonSelect,
-body.dark-mode #sortSelect {
+body.dark-mode #sortSelect,
+body.dark-mode #statusFilterSelect {
   background: #3d3d3d !important;
   border-color: #555 !important;
   color: #e0e0e0;
 }
 
 body.dark-mode #iconicTaxonSelect option,
-body.dark-mode #sortSelect option {
+body.dark-mode #sortSelect option,
+body.dark-mode #statusFilterSelect option {
   background: #3d3d3d;
   color: #e0e0e0;
 }

--- a/lifelist.html
+++ b/lifelist.html
@@ -710,6 +710,13 @@
         <option value="ja">Japanese</option>
         <option value="zh">Chinese</option>
       </select>
+      <select id="statusSelect" class="language-select" style="padding: 10px 15px; border: 2px solid #ddd; border-radius: 5px; font-size: 14px; cursor: pointer;">
+        <option value="" selected>All species</option>
+        <option value="native">Native</option>
+        <option value="introduced">Introduced</option>
+        <option value="threatened">Threatened</option>
+        <option value="endemic">Endemic</option>
+      </select>
       <button id="searchBtn" onclick="startSearch()">Load Lifelist</button>
       <label class="checkbox-label">
         <input type="checkbox" id="casualCheckbox" checked />
@@ -1214,11 +1221,13 @@
         const localeParam = `&locale=${selectedLanguage}`;
         const includeCasual = document.getElementById("casualCheckbox").checked;
         const qualityGradeParam = includeCasual ? "casual,needs_id,research" : "needs_id,research";
+        const speciesStatus = document.getElementById("statusSelect").value;
         let baseUrl = `${API_BASE}/observations/species_counts?per_page=${perPage}&quality_grade=${qualityGradeParam}${localeParam}`;
         if (username) baseUrl += `&user_login=${username}`;
         if (placeId) baseUrl += `&place_id=${placeId}`;
         if (projectId) baseUrl += `&project_id=${projectId}`;
         if (taxonId) baseUrl += `&taxon_id=${taxonId}`;
+        if (speciesStatus) baseUrl += `&${speciesStatus}=true`;
 
         // Fetch first page to get total count
         updateProgress(0, "Fetching species list (page 1)...", "");

--- a/profile.html
+++ b/profile.html
@@ -453,22 +453,22 @@
 
           // Group 2: /identifications endpoint
           const identificationsGroup = async () => {
-            const improvingResponse = await fetch(`https://api.inaturalist.org/v1/identifications?user_id=${user.id}&category=improving&own_observation=false&per_page=0`);
+            const improvingResponse = await fetch(`https://api.inaturalist.org/v1/identifications?user_id=${user.id}&category=improving&own_observation=false&current=true&current_taxon=true&per_page=0`);
             const improvingData = await improvingResponse.json();
             incrementLoadingProgress();
             await delay(500);
 
-            const supportingResponse = await fetch(`https://api.inaturalist.org/v1/identifications?user_id=${user.id}&category=supporting&own_observation=false&per_page=0`);
+            const supportingResponse = await fetch(`https://api.inaturalist.org/v1/identifications?user_id=${user.id}&category=supporting&own_observation=false&current=true&current_taxon=true&per_page=0`);
             const supportingData = await supportingResponse.json();
             incrementLoadingProgress();
             await delay(500);
 
-            const leadingResponse = await fetch(`https://api.inaturalist.org/v1/identifications?user_id=${user.id}&category=leading&own_observation=false&per_page=0`);
+            const leadingResponse = await fetch(`https://api.inaturalist.org/v1/identifications?user_id=${user.id}&category=leading&own_observation=false&current=true&current_taxon=true&per_page=0`);
             const leadingData = await leadingResponse.json();
             incrementLoadingProgress();
             await delay(500);
 
-            const maverickResponse = await fetch(`https://api.inaturalist.org/v1/identifications?user_id=${user.id}&category=maverick&own_observation=false&per_page=0`);
+            const maverickResponse = await fetch(`https://api.inaturalist.org/v1/identifications?user_id=${user.id}&category=maverick&own_observation=false&current=true&current_taxon=true&per_page=0`);
             const maverickData = await maverickResponse.json();
             incrementLoadingProgress();
 

--- a/species-observed.html
+++ b/species-observed.html
@@ -732,22 +732,26 @@
             <option value="Actinopterygii">Actinopterygii</option>
             <option value="Reptilia">Reptilia</option>
           </select>
-          <label
+          <label for="statusFilterSelect" style="margin-left: 20px"
+            >Status:</label
+          >
+          <select
+            id="statusFilterSelect"
             style="
-              margin-left: 20px;
-              display: inline-flex;
-              align-items: center;
-              gap: 6px;
+              padding: 8px 12px;
+              border: 2px solid #ddd;
+              border-radius: 5px;
+              font-size: 14px;
+              background: white;
               cursor: pointer;
             "
           >
-            <input
-              type="checkbox"
-              id="conservationStatusFilter"
-              style="width: 16px; height: 16px; cursor: pointer"
-            />
-            <span>Threatened</span>
-          </label>
+            <option value="">All species</option>
+            <option value="native">Native</option>
+            <option value="introduced">Introduced</option>
+            <option value="threatened">Threatened</option>
+            <option value="endemic">Endemic</option>
+          </select>
           <label for="sortSelect" style="margin-left: 20px">Sort by:</label>
           <select id="sortSelect">
             <option value="user">User Observations (High to Low)</option>
@@ -820,9 +824,7 @@
       const summaryCard = document.getElementById("summaryCard");
       const controls = document.getElementById("controls");
       const iconicTaxonSelect = document.getElementById("iconicTaxonSelect");
-      const conservationStatusFilter = document.getElementById(
-        "conservationStatusFilter"
-      );
+      const statusFilterSelect = document.getElementById("statusFilterSelect");
       const sortSelect = document.getElementById("sortSelect");
       const filterInput = document.getElementById("filterInput");
       const viewControls = document.getElementById("viewControls");
@@ -835,6 +837,7 @@
       let threatenedTaxonIds = new Set();
       let endemicTaxonIds = new Set();
       let introducedTaxonIds = new Set();
+      let nativeTaxonIds = new Set();
       let researchGradeCount = 0;
       let needsIdCount = 0;
       let currentUserId = null;
@@ -1023,8 +1026,8 @@
         displaySpecies();
       });
 
-      // Conservation status filter handler
-      conservationStatusFilter.addEventListener("change", () => {
+      // Species status filter handler (native/introduced/threatened/endemic)
+      statusFilterSelect.addEventListener("change", () => {
         displaySpecies();
       });
 
@@ -1273,6 +1276,45 @@
             });
           }
 
+          // Fetch native species ids (for the status filter)
+          nativeTaxonIds = new Set();
+          const nativePerPage = 500;
+          const firstNativeResponse = await fetch(
+            `https://api.inaturalist.org/v1/observations/species_counts?user_id=${userId}&per_page=${nativePerPage}&page=1&native=true${placeParam}${taxonParam}${dateParam}`
+          );
+          const firstNativeData = await firstNativeResponse.json();
+          const nativeTotalResults = firstNativeData.total_results || 0;
+
+          if (firstNativeData.results) {
+            firstNativeData.results.forEach((item) => {
+              if (item.taxon && item.taxon.id) {
+                nativeTaxonIds.add(item.taxon.id);
+              }
+            });
+          }
+
+          const nativeTotalPages = Math.ceil(nativeTotalResults / nativePerPage);
+          if (nativeTotalPages > 1) {
+            const nativePromises = [];
+            for (let page = 2; page <= nativeTotalPages; page++) {
+              nativePromises.push(
+                fetch(
+                  `https://api.inaturalist.org/v1/observations/species_counts?user_id=${userId}&per_page=${nativePerPage}&page=${page}&native=true${placeParam}${taxonParam}${dateParam}`
+                )
+                  .then((response) => response.json())
+                  .then((data) => data.results || [])
+              );
+            }
+            const additionalNativeResults = await Promise.all(nativePromises);
+            additionalNativeResults.forEach((results) => {
+              results.forEach((item) => {
+                if (item.taxon && item.taxon.id) {
+                  nativeTaxonIds.add(item.taxon.id);
+                }
+              });
+            });
+          }
+
           // Fetch research grade and needs ID species counts
           const [researchResponse, needsIdResponse] = await Promise.all([
             fetch(
@@ -1310,7 +1352,7 @@
         // Filter data based on text input and iconic taxon
         const filterText = filterInput.value.trim().toLowerCase();
         const iconicTaxon = iconicTaxonSelect.value;
-        const onlyWithConservationStatus = conservationStatusFilter.checked;
+        const statusFilter = statusFilterSelect.value;
         let filteredData = speciesData;
 
         // Filter by iconic taxon
@@ -1320,11 +1362,20 @@
           });
         }
 
-        // Filter by threatened species (using API-fetched threatened taxon IDs)
-        if (onlyWithConservationStatus) {
-          filteredData = filteredData.filter((item) => {
-            return item.taxon && threatenedTaxonIds.has(item.taxon.id);
-          });
+        // Filter by species status (using API-fetched taxon ID sets)
+        if (statusFilter) {
+          const statusSets = {
+            native: nativeTaxonIds,
+            introduced: introducedTaxonIds,
+            threatened: threatenedTaxonIds,
+            endemic: endemicTaxonIds,
+          };
+          const statusSet = statusSets[statusFilter];
+          if (statusSet) {
+            filteredData = filteredData.filter((item) => {
+              return item.taxon && statusSet.has(item.taxon.id);
+            });
+          }
         }
 
         // Filter by text


### PR DESCRIPTION
Two changes from user feedback (nicolashelitas):

## 1. Profile identification counts match achievements

The profile queried `/v1/identifications?category=...` with no `current` filter, counting every identification record ever made — including IDs later withdrawn or replaced. Achievements filters with `current=true&current_taxon=true`, so the same user saw 162 leading IDs on one page and 53 on the other. The profile's four category queries now use the same filters, consistent with iNaturalist's own identifications tab.

## 2. Species status filter (native / introduced / threatened / endemic)

New "Status" combobox on two tools:

- **Lifelist timeline**: the selected status is passed to the `species_counts` API query (`native=true`, `introduced=true`, `threatened=true`, or `endemic=true`), so the whole timeline is built from the filtered species set.
- **Species observed**: replaces the previous threatened-only checkbox with the same four-option select. Native taxon ids are fetched alongside the existing threatened/endemic/introduced id sets, and filtering stays client-side and instant. Dark mode styling included.

## Testing

Exercised both flows in a browser with stubbed API responses: species-observed correctly narrows 6 stub species to 4 native / 2 introduced / 2 threatened / 1 endemic as the select changes, and lifelist's `species_counts` request URL carries the selected status param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCN7BpBma5rdR4fdeDXfjh