### PR TITLE
Detect CNC 2026+ participation and count all fish classes in achievements

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -180,6 +180,29 @@
         { id: 227779, year: 2025 },
       ];
 
+      // The CNC umbrella project uses the same slug pattern every year;
+      // resolve years newer than the hardcoded list at runtime so the
+      // achievement keeps working without an annual code change.
+      async function loadNewerCncProjects() {
+        const lastKnownYear = CNC_PROJECTS[CNC_PROJECTS.length - 1].year;
+        const currentYear = new Date().getFullYear();
+        const found = [];
+        for (let year = lastKnownYear + 1; year <= currentYear; year++) {
+          try {
+            const res = await fetch(
+              `https://api.inaturalist.org/v1/projects/city-nature-challenge-${year}`
+            );
+            const data = await res.json();
+            if (data.results && data.results[0] && data.results[0].id) {
+              found.push({ id: data.results[0].id, year });
+            }
+          } catch (e) {
+            // project for that year doesn't exist (yet) - skip it
+          }
+        }
+        return found;
+      }
+
       // Load username from URL parameter or localStorage
       const urlParams = new URLSearchParams(window.location.search);
       const urlUsername = urlParams.get("user");
@@ -651,7 +674,8 @@
           refreshAchievements();
 
           // Fetch City Nature Challenge participation (3 parallel batches)
-          const cncTasks = CNC_PROJECTS.map(project => () =>
+          const allCncProjects = CNC_PROJECTS.concat(await loadNewerCncProjects());
+          const cncTasks = allCncProjects.map(project => () =>
             fetch(`https://api.inaturalist.org/v1/observations?user_id=${userId}&project_id=${project.id}&per_page=1`)
               .then((res) => res.json())
               .then((data) => { updateProgress(); return data; })
@@ -660,7 +684,7 @@
 
           state.cncYears = cncResults
             .map((result, index) => ({
-              year: CNC_PROJECTS[index].year,
+              year: allCncProjects[index].year,
               participated: (result.total_results || 0) > 0,
             }))
             .filter((item) => item.participated)


### PR DESCRIPTION
Two achievement fixes from user feedback (nicolashelitas).

## 1. City Nature Challenge 2026+ detection

The CNC achievement checked a hardcoded list of umbrella project ids ending at 2025, so participation in CNC 2026 was never detected (2016–2025 were all present; only newer years were missing). Keep the known ids and resolve newer years at runtime through the stable `city-nature-challenge-YYYY` project slug, so it keeps working every year without a code change. Non-existent year slugs are skipped gracefully.

## 2. Fish Expert counts all fish, not just ray-finned

The Fish Expert badge counted only the Actinopterygii iconic taxon, so sharks & rays (Chondrichthyes), jawless fish (Agnatha), and lobe-finned fish were excluded and lumped under "Other Animals" — inconsistent with polyphyletic groupings like Raptor Watcher. Fish are now counted by ancestor taxon across all classes.

**Safety note:** Sarcopterygii is intentionally *not* used as an ancestor node, because cladistically it contains all tetrapods (a naive include would count every bird/mammal/reptile/amphibian as a fish). Its two living fish orders — coelacanths (Coelacanthiformes) and lungfishes (Ceratodontiformes) — are listed directly instead. The separate "observe all iconic taxa" achievement is untouched and still uses the true iconic-taxon count.

Taxon ids used: Actinopterygii 47178, Chondrichthyes 196614, Agnatha 797045, Coelacanthiformes 85511, Ceratodontiformes 85509. The badge's "view on iNaturalist" link now targets all of them.

## Testing

Both exercised in a browser with stubbed API data:
- CNC: page queries the ten legacy ids plus the slug-resolved 2026 id; achievement renders "Participate in a City Nature Challenge (2024, 2025, 2026)".
- Fish: a set of 3 ray-finned + 2 sharks + 1 lamprey + 1 coelacanth + 4 birds (one a raptor) yields Fish Expert 7/100 — all real fish counted, no tetrapod miscounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCN7BpBma5rdR4fdeDXfjh