### PR TITLE
Lifelist newest-first during load + switch feedback widget to Crisp

### DIFF
--- a/achievements.html
+++ b/achievements.html
@@ -2897,15 +2897,18 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <!-- <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
     </script> -->
     <script>
       if ('serviceWorker' in navigator) {

--- a/draft.html
+++ b/draft.html
@@ -4845,24 +4845,27 @@
     <script src="dark-mode.js"></script>
     <button class="feedback-button" id="feedbackBtn">Send feedback</button>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/first-identifier.html
+++ b/first-identifier.html
@@ -1042,24 +1042,27 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/first-observer.html
+++ b/first-observer.html
@@ -1014,24 +1014,27 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/index.html
+++ b/index.html
@@ -433,24 +433,27 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/lifelist.html
+++ b/lifelist.html
@@ -792,7 +792,7 @@
         gridEl.appendChild(div);
       }
 
-      function addGridItem(sp, number) {
+      function addGridItem(sp, number, prepend = false) {
         const gridEl = document.getElementById("speciesGrid");
         const a = document.createElement("a");
         a.className = "species-card";
@@ -829,7 +829,11 @@
             ${observerDisplay}
           </div>
         `;
-        gridEl.appendChild(a);
+        if (prepend) {
+          gridEl.insertBefore(a, gridEl.firstChild);
+        } else {
+          gridEl.appendChild(a);
+        }
       }
       const autocompleteEl = document.getElementById("autocomplete");
 
@@ -1418,7 +1422,7 @@
         listEl.appendChild(li);
       }
 
-      function addResultItem(sp, number) {
+      function addResultItem(sp, number, prepend = false) {
         const listEl = document.getElementById("speciesList");
         const a = document.createElement("a");
         a.className = "species-item";
@@ -1460,7 +1464,14 @@
           <span class="species-date">${sp.observedOn}${observerDisplay}</span>
         </div>
       `;
-        listEl.appendChild(a);
+        // During loading, observations arrive oldest-first (order=asc, to capture
+        // each species' first sighting), so prepend to keep the live preview
+        // newest-first — matching the final sorted order.
+        if (prepend) {
+          listEl.insertBefore(a, listEl.firstChild);
+        } else {
+          listEl.appendChild(a);
+        }
       }
 
       function showNoResults() {
@@ -1593,8 +1604,8 @@
                 observerName: result.observerName,
                 showObserver: !username,
               };
-              addResultItem(itemData, foundCount);
-              addGridItem(itemData, foundCount);
+              addResultItem(itemData, foundCount, true);
+              addGridItem(itemData, foundCount, true);
             },
             placeId,
             projectId

--- a/lifelist.html
+++ b/lifelist.html
@@ -1684,24 +1684,27 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/profile.html
+++ b/profile.html
@@ -1611,24 +1611,27 @@
     <button class="feedback-button" id="feedbackBtn">Send feedback</button>
     <script defer data-domain="glauberramos.github.io/inat" src="https://plausible.io/js/script.js"></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/project-search.html
+++ b/project-search.html
@@ -821,24 +821,27 @@
     ></script>
     <button class="feedback-button" id="feedbackBtn">Send feedback</button>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/shared-utils.js
+++ b/shared-utils.js
@@ -112,13 +112,13 @@ function updateProgress(percent, text, currentCheck) {
 function initFeedbackButton(buttonId = "feedbackBtn") {
   let feedbackOpen = false;
   const btn = document.getElementById(buttonId);
-  if (btn && typeof $pipeback !== "undefined") {
+  if (btn && typeof $crisp !== "undefined") {
     btn.addEventListener("click", () => {
       if (feedbackOpen) {
-        $pipeback.close();
+        $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
         feedbackOpen = false;
       } else {
-        $pipeback.open();
+        $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
         feedbackOpen = true;
       }
     });

--- a/species-compare.html
+++ b/species-compare.html
@@ -1087,24 +1087,27 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/species-identified.html
+++ b/species-identified.html
@@ -1390,24 +1390,27 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/species-observed.html
+++ b/species-observed.html
@@ -1695,24 +1695,27 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/speciesdex.html
+++ b/speciesdex.html
@@ -1404,24 +1404,27 @@
     ></script>
     <button class="feedback-button" id="feedbackBtn">Send feedback</button>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/taxonomy-completion.html
+++ b/taxonomy-completion.html
@@ -1006,24 +1006,27 @@
     </script>
     <button class="feedback-button" id="feedbackBtn">Send feedback</button>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/us-states.html
+++ b/us-states.html
@@ -682,24 +682,27 @@
     <button class="feedback-button" id="feedbackBtn">Send feedback</button>
     <script defer data-domain="glauberramos.github.io/inat" src="https://plausible.io/js/script.js"></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/users-compare.html
+++ b/users-compare.html
@@ -1048,24 +1048,27 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       // Feedback button toggle
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });

--- a/widget.html
+++ b/widget.html
@@ -1459,23 +1459,26 @@
       src="https://plausible.io/js/script.js"
     ></script>
     <script type="text/javascript">
-      window.$pipeback = [];
-      window.PIPEBACK_ID = "a069b910-4aef-4233-99cc-913e7fb30fb5";
+      window.$crisp = [];
+      window.CRISP_WEBSITE_ID = "69e5f089-9f10-41ef-a438-5d254be7b317";
       (function () {
         d = document;
         s = d.createElement("script");
-        s.src = "https://widget.pipeback.com/l.js";
+        s.src = "https://client.crisp.chat/l.js";
         s.async = 1;
         d.getElementsByTagName("head")[0].appendChild(s);
       })();
+      // Hide Crisp's default launcher; the "Send feedback" button opens the chat.
+      $crisp.push(["do", "chat:hide"]);
+      $crisp.push(["on", "chat:closed", function () { $crisp.push(["do", "chat:hide"]); }]);
 
       let feedbackOpen = false;
       document.getElementById("feedbackBtn").addEventListener("click", () => {
         if (feedbackOpen) {
-          $pipeback.close();
+          $crisp.push(["do", "chat:close"]); $crisp.push(["do", "chat:hide"]);
           feedbackOpen = false;
         } else {
-          $pipeback.open();
+          $crisp.push(["do", "chat:show"]); $crisp.push(["do", "chat:open"]);
           feedbackOpen = true;
         }
       });


### PR DESCRIPTION
Two independent changes from this session, in separate commits.

## 1. Lifelist: newest-first during loading

The final render already sorted newest-first, but each species was **appended** as found during loading. The batch fetch uses `order_by=observed_on&order=asc` (oldest observation first — correct for capturing each species' *first* sighting), so the live preview filled in oldest-first and only flipped at the end. Now the preview **prepends** (via an optional `prepend` flag on `addResultItem`/`addGridItem`), so it reads newest-first throughout. First-sighting logic and final render unchanged. Verified in a browser: final order newest-first (2024→2018) with correct year separators.

## 2. Replace Pipeback with Crisp

Swaps the Pipeback loader for Crisp (website id `69e5f089-…`) across all pages and `shared-utils.js`. Per the chosen UX, the custom green **"Send feedback" button stays the only launcher**: Crisp's default bubble is hidden on load (and re-hidden whenever the chat is closed), and the button shows+opens the Crisp chat. `achievements.html` keeps its feedback widget commented out, exactly as it was under Pipeback.

Verified in a browser (Crisp loader stubbed): the Crisp script is injected with the correct website id, `chat:hide` is queued on load, clicking "Send feedback" pushes `chat:show` + `chat:open`, and there are no page errors. The now-inert `.pipeback-launcher-frame` CSS hide rules were left in place (harmless; they match no elements now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCN7BpBma5rdR4fdeDXfjh