### PR TITLE
Fix projects section overflowing the screen on mobile profile page

### DIFF
--- a/profile.css
+++ b/profile.css
@@ -826,6 +826,8 @@ a.taxon-bar-col:hover {
   text-decoration: none;
   color: #333;
   transition: all 0.2s;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .project-item:hover {
@@ -838,11 +840,13 @@ a.taxon-bar-col:hover {
   height: 24px;
   border-radius: 4px;
   object-fit: cover;
+  flex-shrink: 0;
 }
 
 .project-name {
   font-size: 14px;
   font-weight: 500;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -890,6 +894,7 @@ a.taxon-bar-col:hover {
 @media (max-width: 768px) {
   .projects-list {
     flex-direction: column;
+    flex-wrap: nowrap;
   }
 
   .projects-category-list {


### PR DESCRIPTION
## Problem

On the mobile profile page, the Projects card rendered wider than the screen, breaking the whole page layout (horizontal overflow, everything cut off at the edges).

## Root cause

The base `.projects-list` rule sets `flex-wrap: wrap`, and the mobile media query only switched it to `flex-direction: column`. In a **wrapping column** flex container, each flex line's cross-size is content-driven rather than container-driven, so the long non-wrapping project names (e.g. "Mapeamento da Biodiversidade do Litoral Norte do Rio Grande do Sul") forced `.projects-category` to ~496px inside a 338px container. That overflow expanded the mobile layout viewport, breaking the entire page.

## Fix (`profile.css`)

- Add `flex-wrap: nowrap` to `.projects-list` in the mobile media query, so categories stretch to the container width instead of their content width.
- Add `min-width: 0` to `.project-name` (and `min-width: 0; max-width: 100%` to `.project-item`) so the existing `text-overflow: ellipsis` can actually truncate long names.
- Add `flex-shrink: 0` to `.project-icon` so icons don't get squashed next to long names.

## Verification

Reproduced and verified with headless Chromium (390px mobile viewport, mocked iNaturalist API responses using the project names from the bug report):

- Before: document scroll width 522px vs 390px viewport, project items 491px wide.
- After: document scroll width exactly 390px, all project items fit (333px), long names ellipsize.
- Desktop (1280px): three equal 386px columns, unchanged layout, long names now ellipsize instead of overflowing their column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013f9FRuRKdPpiQDpByjDpeH

---
_Generated by [Claude Code](https://claude.ai/code/session_013f9FRuRKdPpiQDpByjDpeH)_