### PR TITLE
Widget: taxa search option + always-visible tile names on mobile

### DIFF
--- a/inat-widget.js
+++ b/inat-widget.js
@@ -43,6 +43,9 @@
       this.compact = container.dataset.inatCompact === "true";
       this.lang = container.dataset.inatLang || "";
       this.pagination = container.dataset.inatPagination === "true";
+      this.searchEnabled = container.dataset.inatSearch === "true";
+      this.showNames = container.dataset.inatShowNames === "true";
+      this.searchTaxon = null;
       this.page = 1;
       this.totalResults = 0;
       this.observations = [];
@@ -297,6 +300,13 @@
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
+        }
+        /* Touch devices have no hover — always show tile names */
+        @media (hover: none) {
+          .inat-w-grid-item .inat-w-grid-overlay { opacity: 1; }
+        }
+        .inat-w-grid.inat-w-show-names .inat-w-grid-overlay {
+          opacity: 1;
         }
         /* Photo count badge on grid */
         .inat-w-photo-count {
@@ -584,6 +594,102 @@
           white-space: nowrap;
         }
 
+        /* Taxa search */
+        .inat-w-search {
+          position: relative;
+          margin-bottom: 12px;
+        }
+        .inat-w-search-input {
+          width: 100%;
+          padding: 8px 30px 8px 32px;
+          border: 1.5px solid var(--inat-border);
+          border-radius: var(--inat-radius-sm);
+          font-size: 13px;
+          font-family: inherit;
+          background: var(--inat-card-bg);
+          color: var(--inat-text);
+          outline: none;
+          transition: border-color 0.15s;
+        }
+        .inat-w-search-input::placeholder { color: var(--inat-text-secondary); }
+        .inat-w-search-input:focus { border-color: var(--inat-accent); }
+        .inat-w-search-icon {
+          position: absolute;
+          left: 10px;
+          top: 50%;
+          transform: translateY(-50%);
+          font-size: 12px;
+          pointer-events: none;
+        }
+        .inat-w-search-clear {
+          position: absolute;
+          right: 6px;
+          top: 50%;
+          transform: translateY(-50%);
+          width: 20px;
+          height: 20px;
+          border: none;
+          border-radius: 50%;
+          background: var(--inat-border);
+          color: var(--inat-text-secondary);
+          font-size: 13px;
+          line-height: 1;
+          cursor: pointer;
+          display: none;
+          align-items: center;
+          justify-content: center;
+        }
+        .inat-w-search-clear.inat-w-visible { display: flex; }
+        .inat-w-search-results {
+          position: absolute;
+          top: 100%;
+          left: 0;
+          right: 0;
+          margin-top: 4px;
+          background: var(--inat-card-bg);
+          border: 1px solid var(--inat-border);
+          border-radius: var(--inat-radius-sm);
+          box-shadow: var(--inat-shadow-hover);
+          max-height: 220px;
+          overflow-y: auto;
+          z-index: 20;
+          display: none;
+        }
+        .inat-w-search-results.inat-w-visible { display: block; }
+        .inat-w-search-item {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 6px 10px;
+          cursor: pointer;
+        }
+        .inat-w-search-item:hover { background: var(--inat-hover); }
+        .inat-w-search-item img {
+          width: 28px;
+          height: 28px;
+          border-radius: 50%;
+          object-fit: cover;
+          background: var(--inat-border);
+          flex-shrink: 0;
+        }
+        .inat-w-search-item-info { flex: 1; min-width: 0; }
+        .inat-w-search-item-name {
+          font-size: 12px;
+          font-weight: 600;
+          color: var(--inat-text);
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .inat-w-search-item-sub {
+          font-size: 10px;
+          color: var(--inat-text-secondary);
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+        .inat-w-search-item-sub em { font-style: italic; }
+
         /* Placeholder image */
         .inat-w-no-photo {
           display: flex;
@@ -618,6 +724,11 @@
       `;
       this.container.appendChild(header);
 
+      // Taxa search bar
+      if (this.searchEnabled && this.sourceType !== "observation") {
+        this.renderSearchBar();
+      }
+
       // Content area
       this.contentEl = document.createElement("div");
       this.contentEl.innerHTML = `<div class="inat-w-loading"><div class="inat-w-spinner"></div><span>Loading observations…</span></div>`;
@@ -633,6 +744,109 @@
       footer.className = "inat-w-footer";
       footer.innerHTML = `<a href="${this.getSourceUrl()}" target="_blank" rel="noopener">View more on iNaturalist &rarr;</a>`;
       this.container.appendChild(footer);
+    }
+
+    renderSearchBar() {
+      const bar = document.createElement("div");
+      bar.className = "inat-w-search";
+      bar.innerHTML = `
+        <span class="inat-w-search-icon">&#x1F50D;</span>
+        <input type="text" class="inat-w-search-input" placeholder="Search any taxa (birds, oaks, fungi…)" autocomplete="off" />
+        <button type="button" class="inat-w-search-clear" aria-label="Clear search">&times;</button>
+        <div class="inat-w-search-results"></div>
+      `;
+      this.container.appendChild(bar);
+
+      const input = bar.querySelector(".inat-w-search-input");
+      const clearBtn = bar.querySelector(".inat-w-search-clear");
+      const results = bar.querySelector(".inat-w-search-results");
+      let searchTimeout = null;
+
+      const hideResults = () => results.classList.remove("inat-w-visible");
+
+      const applyTaxon = (taxonId, label) => {
+        this.searchTaxon = taxonId;
+        this.page = 1;
+        input.value = label || "";
+        clearBtn.classList.toggle("inat-w-visible", !!taxonId);
+        hideResults();
+        this.contentEl.innerHTML = `<div class="inat-w-loading"><div class="inat-w-spinner"></div><span>Loading…</span></div>`;
+        this.fetchObservations();
+      };
+
+      input.addEventListener("input", () => {
+        const q = input.value.trim();
+        clearTimeout(searchTimeout);
+        if (q.length < 2) {
+          hideResults();
+          // Reset filter when the box is emptied after an active search
+          if (q.length === 0 && this.searchTaxon) applyTaxon(null, "");
+          return;
+        }
+        searchTimeout = setTimeout(() => this.fetchTaxaSuggestions(q, results, applyTaxon), 300);
+      });
+
+      input.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") hideResults();
+        if (e.key === "Enter") {
+          const first = results.querySelector(".inat-w-search-item");
+          if (first) first.click();
+        }
+      });
+
+      clearBtn.addEventListener("click", () => applyTaxon(null, ""));
+
+      document.addEventListener("click", (e) => {
+        if (!bar.contains(e.target)) hideResults();
+      });
+    }
+
+    async fetchTaxaSuggestions(query, resultsEl, applyTaxon) {
+      try {
+        const params = new URLSearchParams({ q: query, per_page: 6 });
+        if (this.lang) params.set("locale", this.lang);
+        const res = await fetch(`${INAT_API}/taxa/autocomplete?${params.toString()}`);
+        if (!res.ok) throw new Error("autocomplete failed");
+        const data = await res.json();
+        const taxa = data.results || [];
+        resultsEl.innerHTML = "";
+        if (!taxa.length) {
+          resultsEl.classList.remove("inat-w-visible");
+          return;
+        }
+        taxa.forEach((t) => {
+          const displayName = t.preferred_common_name || t.name;
+          const item = document.createElement("div");
+          item.className = "inat-w-search-item";
+
+          const img = document.createElement("img");
+          img.src = t.default_photo && t.default_photo.square_url ? t.default_photo.square_url : "";
+          img.alt = "";
+          img.loading = "lazy";
+
+          const info = document.createElement("div");
+          info.className = "inat-w-search-item-info";
+          const nameEl = document.createElement("div");
+          nameEl.className = "inat-w-search-item-name";
+          nameEl.textContent = displayName;
+          const subEl = document.createElement("div");
+          subEl.className = "inat-w-search-item-sub";
+          const sciEl = document.createElement("em");
+          sciEl.textContent = t.name;
+          subEl.appendChild(sciEl);
+          subEl.appendChild(document.createTextNode(t.rank ? ` · ${t.rank}` : ""));
+          info.appendChild(nameEl);
+          info.appendChild(subEl);
+
+          item.appendChild(img);
+          item.appendChild(info);
+          item.addEventListener("click", () => applyTaxon(t.id, displayName));
+          resultsEl.appendChild(item);
+        });
+        resultsEl.classList.add("inat-w-visible");
+      } catch (err) {
+        resultsEl.classList.remove("inat-w-visible");
+      }
     }
 
     renderPagination() {
@@ -727,9 +941,10 @@
           params.set("locale", this.lang);
         }
 
-        // Taxon filter
-        if (this.taxon) {
-          params.set("taxon_id", this.taxon);
+        // Taxon filter (in-widget search takes precedence over the configured filter)
+        const taxonFilter = this.searchTaxon || this.taxon;
+        if (taxonFilter) {
+          params.set("taxon_id", taxonFilter);
         }
 
         // Quality grade filter
@@ -841,7 +1056,7 @@
 
     renderGrid() {
       const wrap = document.createElement("div");
-      wrap.className = "inat-w-grid" + (this.compact ? " inat-w-compact" : "");
+      wrap.className = "inat-w-grid" + (this.compact ? " inat-w-compact" : "") + (this.showNames ? " inat-w-show-names" : "");
 
       this.observations.forEach((obs) => {
         const name = this.getCommonName(obs);
@@ -1046,7 +1261,7 @@
 
     renderSpeciesGrid() {
       const wrap = document.createElement("div");
-      wrap.className = "inat-w-grid" + (this.compact ? " inat-w-compact" : "");
+      wrap.className = "inat-w-grid" + (this.compact ? " inat-w-compact" : "") + (this.showNames ? " inat-w-show-names" : "");
       this.speciesItems().forEach(({ count, taxon }) => {
         const name = this.speciesCommonName(taxon);
         const sci = this.speciesScientificName(taxon);

--- a/widget-embed.html
+++ b/widget-embed.html
@@ -40,6 +40,8 @@
         show_location: "data-inat-show-location",
         show_grade: "data-inat-show-grade",
         show_notes: "data-inat-show-notes",
+        show_names: "data-inat-show-names",
+        search: "data-inat-search",
         radius: "data-inat-radius",
         padding: "data-inat-padding",
         compact: "data-inat-compact",

--- a/widget.html
+++ b/widget.html
@@ -719,8 +719,10 @@
             <label class="checkbox-label hidden-for-species" id="showLocationLabel"><input type="checkbox" id="showLocation" checked /> Location</label>
             <label class="checkbox-label hidden-for-species" id="showGradeLabel"><input type="checkbox" id="showGrade" /> Research Grade</label>
             <label class="checkbox-label hidden-for-species" id="showNotesLabel"><input type="checkbox" id="showNotes" /> Notes</label>
+            <label class="checkbox-label" id="showNamesLabel"><input type="checkbox" id="showNames" /> Always show names</label>
             <label class="checkbox-label" id="compactLabel"><input type="checkbox" id="compact" /> Compact</label>
             <label class="checkbox-label"><input type="checkbox" id="paginationCheck" /> Pagination</label>
+            <label class="checkbox-label"><input type="checkbox" id="searchCheck" /> Taxa search</label>
           </div>
           <div class="option-row">
             <div class="option-label">Custom text (top right)</div>
@@ -904,6 +906,8 @@
         showNotes: false,
         compact: false,
         pagination: false,
+        search: false,
+        showNames: false,
         headerText: "",
         borderRadius: 12,
         padding: 16,
@@ -1016,6 +1020,7 @@
         document.getElementById("showLocationLabel").style.display = isGrid ? "none" : "";
         document.getElementById("showGradeLabel").style.display = isGrid ? "none" : "";
         document.getElementById("showNotesLabel").style.display = isGrid ? "none" : "";
+        document.getElementById("showNamesLabel").style.display = isGrid ? "" : "none";
         document.getElementById("compactLabel").style.display = hasCompact ? "" : "none";
       }
 
@@ -1105,6 +1110,18 @@
 
       document.getElementById("paginationCheck").addEventListener("change", (e) => {
         state.pagination = e.target.checked;
+        renderPreview();
+        updateEmbedCode();
+      });
+
+      document.getElementById("searchCheck").addEventListener("change", (e) => {
+        state.search = e.target.checked;
+        renderPreview();
+        updateEmbedCode();
+      });
+
+      document.getElementById("showNames").addEventListener("change", (e) => {
+        state.showNames = e.target.checked;
         renderPreview();
         updateEmbedCode();
       });
@@ -1396,8 +1413,10 @@
         }
         if (state.borderRadius !== 12) attrs.push(`data-inat-radius="${state.borderRadius}"`);
         if (state.padding !== 16) attrs.push(`data-inat-padding="${state.padding}"`);
+        if (state.showNames && state.layout === "grid") attrs.push(`data-inat-show-names="true"`);
         if (state.compact) attrs.push(`data-inat-compact="true"`);
         if (state.pagination && state.sourceType !== "observation") attrs.push(`data-inat-pagination="true"`);
+        if (state.search && state.sourceType !== "observation") attrs.push(`data-inat-search="true"`);
         if (state.lang) attrs.push(`data-inat-lang="${escapeAttr(state.lang)}"`);
 
         return attrs;
@@ -1449,8 +1468,10 @@
           }
           if (state.borderRadius !== 12) params.set("radius", state.borderRadius);
           if (state.padding !== 16) params.set("padding", state.padding);
+          if (state.showNames && state.layout === "grid") params.set("show_names", "true");
           if (state.compact) params.set("compact", "true");
           if (state.pagination && state.sourceType !== "observation") params.set("pagination", "true");
+          if (state.search && state.sourceType !== "observation") params.set("search", "true");
           if (state.lang) params.set("lang", state.lang);
           const iframeUrl = `${WIDGET_EMBED_URL}?${params.toString()}`;
           const code = `<!-- iNaturalist Widget (iframe) -->\n<iframe\n  src="${iframeUrl}"\n  width="100%"\n  height="100%"\n  frameborder="0"\n  style="border:none;border-radius:12px"\n></iframe>`;


### PR DESCRIPTION
Addresses user feedback on the observations widget:

## Taxa search (any taxa, not just species)
- New **"Taxa search"** checkbox in the widget builder. When enabled, the widget itself renders a search box that lets visitors filter the displayed observations (or top species) by **any taxon** — species, genus, family, order, class, etc. — using iNaturalist's `taxa/autocomplete` API.
- The dropdown shows the common name, scientific name, and rank for each suggestion; selecting one refetches with `taxon_id`, and a ✕ button clears the filter back to the original view.
- Works for observations and Top Species modes, respects the widget's language setting, and is themed to match all four widget themes.
- Exposed as `data-inat-search="true"` (script embed) and `search=true` (iframe embed).

## Mobile: tile names without hover
- On touch devices (`@media (hover: none)`), grid tile overlays with the common name and scientific name are now **always visible** — no hover exists on mobile, and tapping the tile opens the iNaturalist page, so names were previously unreachable there.
- New **"Always show names"** option for the grid layout (`data-inat-show-names="true"` / `show_names=true`) to keep the name overlays permanently visible on desktop too.

## Testing
Verified in headless Chromium (with mocked API responses, since the sandbox blocks api.inaturalist.org): search box renders and filters by class/kingdom-rank taxa, clear button resets, Enter selects the first suggestion, overlays visible on emulated touch devices and with the show-names option, builder checkboxes toggle correctly per layout, and both script and iframe embed codes include the new parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174tfuKvjuwLj1oeJvXsiPr

---
_Generated by [Claude Code](https://claude.ai/code/session_0174tfuKvjuwLj1oeJvXsiPr)_