### PR TITLE
Widget: option to hide observation counts in Top Species mode

### DIFF
--- a/inat-widget.js
+++ b/inat-widget.js
@@ -45,6 +45,7 @@
       this.pagination = container.dataset.inatPagination === "true";
       this.searchEnabled = container.dataset.inatSearch === "true";
       this.showNames = container.dataset.inatShowNames === "true";
+      this.showCount = container.dataset.inatShowCount !== "false";
       this.searchTaxon = null;
       this.page = 1;
       this.totalResults = 0;
@@ -1251,7 +1252,7 @@
             <div class="inat-w-list-name">${this.escapeHtml(name)}</div>
             <div class="inat-w-list-scientific">${this.escapeHtml(sci)}</div>
           </div>
-          <span class="inat-w-count-pill">${this.formatCount(count)}</span>
+          ${this.showCount ? `<span class="inat-w-count-pill">${this.formatCount(count)}</span>` : ""}
         `;
         wrap.appendChild(item);
       });
@@ -1274,7 +1275,7 @@
         item.rel = "noopener";
         item.innerHTML = `
           ${photo ? `<img class="inat-w-grid-img" src="${photo}" alt="${this.escapeHtml(name)}" loading="lazy" />` : `<div class="inat-w-no-photo" style="aspect-ratio:1">&#x1F33F;</div>`}
-          <span class="inat-w-count-badge">${this.formatCount(count)}</span>
+          ${this.showCount ? `<span class="inat-w-count-badge">${this.formatCount(count)}</span>` : ""}
           <div class="inat-w-grid-overlay">
             <div class="inat-w-grid-name">${this.escapeHtml(name)}</div>
             <div class="inat-w-grid-sci">${this.escapeHtml(sci)}</div>
@@ -1302,7 +1303,7 @@
         card.innerHTML = `
           <div class="inat-w-card-cover">
             ${cover ? `<img class="inat-w-card-cover-img" src="${cover}" alt="${this.escapeHtml(name)}" loading="lazy" />` : `<div class="inat-w-no-photo">&#x1F33F;</div>`}
-            <span class="inat-w-count-badge">${this.formatCount(count)} obs</span>
+            ${this.showCount ? `<span class="inat-w-count-badge">${this.formatCount(count)} obs</span>` : ""}
           </div>
           <div class="inat-w-card-body">
             <div class="inat-w-card-common">${this.escapeHtml(name)}</div>

--- a/widget-embed.html
+++ b/widget-embed.html
@@ -41,6 +41,7 @@
         show_grade: "data-inat-show-grade",
         show_notes: "data-inat-show-notes",
         show_names: "data-inat-show-names",
+        show_count: "data-inat-show-count",
         search: "data-inat-search",
         radius: "data-inat-radius",
         padding: "data-inat-padding",

--- a/widget.html
+++ b/widget.html
@@ -720,6 +720,7 @@
             <label class="checkbox-label hidden-for-species" id="showGradeLabel"><input type="checkbox" id="showGrade" /> Research Grade</label>
             <label class="checkbox-label hidden-for-species" id="showNotesLabel"><input type="checkbox" id="showNotes" /> Notes</label>
             <label class="checkbox-label" id="showNamesLabel"><input type="checkbox" id="showNames" /> Always show names</label>
+            <label class="checkbox-label" id="showCountLabel" style="display:none"><input type="checkbox" id="showCount" checked /> Obs count</label>
             <label class="checkbox-label" id="compactLabel"><input type="checkbox" id="compact" /> Compact</label>
             <label class="checkbox-label"><input type="checkbox" id="paginationCheck" /> Pagination</label>
             <label class="checkbox-label"><input type="checkbox" id="searchCheck" /> Taxa search</label>
@@ -908,6 +909,7 @@
         pagination: false,
         search: false,
         showNames: false,
+        showCount: true,
         headerText: "",
         borderRadius: 12,
         padding: 16,
@@ -943,6 +945,7 @@
           el.classList.toggle("species-mode", isSpecies);
         });
         limitLabel.textContent = isSpecies ? "Top Species" : "Observations";
+        document.getElementById("showCountLabel").style.display = isSpecies ? "" : "none";
       }
       document.querySelectorAll("#dataTypeTabs .source-type-tab").forEach((tab) => {
         tab.addEventListener("click", () => {
@@ -1122,6 +1125,12 @@
 
       document.getElementById("showNames").addEventListener("change", (e) => {
         state.showNames = e.target.checked;
+        renderPreview();
+        updateEmbedCode();
+      });
+
+      document.getElementById("showCount").addEventListener("change", (e) => {
+        state.showCount = e.target.checked;
         renderPreview();
         updateEmbedCode();
       });
@@ -1414,6 +1423,7 @@
         if (state.borderRadius !== 12) attrs.push(`data-inat-radius="${state.borderRadius}"`);
         if (state.padding !== 16) attrs.push(`data-inat-padding="${state.padding}"`);
         if (state.showNames && state.layout === "grid") attrs.push(`data-inat-show-names="true"`);
+        if (isSpecies && !state.showCount) attrs.push(`data-inat-show-count="false"`);
         if (state.compact) attrs.push(`data-inat-compact="true"`);
         if (state.pagination && state.sourceType !== "observation") attrs.push(`data-inat-pagination="true"`);
         if (state.search && state.sourceType !== "observation") attrs.push(`data-inat-search="true"`);
@@ -1469,6 +1479,7 @@
           if (state.borderRadius !== 12) params.set("radius", state.borderRadius);
           if (state.padding !== 16) params.set("padding", state.padding);
           if (state.showNames && state.layout === "grid") params.set("show_names", "true");
+          if (isSpecies && !state.showCount) params.set("show_count", "false");
           if (state.compact) params.set("compact", "true");
           if (state.pagination && state.sourceType !== "observation") params.set("pagination", "true");
           if (state.search && state.sourceType !== "observation") params.set("search", "true");


### PR DESCRIPTION
Adds an **"Obs count"** checkbox to the widget builder, shown only when the **Top Species** display is selected (the observation count badges only exist there).

- Checked by default — current behavior is unchanged.
- Unchecking it hides the observation count badge/pill in all three layouts (grid, list, cards).
- Exposed as `data-inat-show-count="false"` in the script embed and `show_count=false` in the iframe embed; the attribute/param is only emitted when counts are turned off.

## Testing
Verified in headless Chromium with mocked API responses: counts render by default and disappear with `show_count=false` in grid, list, and cards layouts; the builder checkbox only appears in Top Species mode; and both embed code outputs emit the parameter only when unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174tfuKvjuwLj1oeJvXsiPr

---
_Generated by [Claude Code](https://claude.ai/code/session_0174tfuKvjuwLj1oeJvXsiPr)_