### PR TITLE
Fix profile identification count mismatch with iNaturalist

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -558,9 +558,10 @@
           lastQualityData = qualityData;
           drawPieChart(qualityData);
 
-          const totalIdentifications = idData.improving + idData.supporting + idData.leading + idData.maverick;
-          document.getElementById('identificationsCount').textContent = totalIdentifications.toLocaleString();
-
+          // Note: don't overwrite #identificationsCount with the sum of the four
+          // category queries. Those queries filter by current_taxon=true and skip
+          // uncategorized IDs, so the sum undercounts compared to the number shown
+          // on the iNaturalist profile (user.identifications_count, set above).
           lastIdData = idData;
           drawIdPieChart(idData);
 


### PR DESCRIPTION
## Problem

Users reported the identification count on the profile page not matching their iNaturalist profile — e.g. `pampasorro` shows 507 on inaturalist.org but 401 on the tools profile page, and another user reported being over 1,000 off (while observation counts matched fine).

## Root cause

`profile.html` first sets the header count from `user.identifications_count` — the exact field inaturalist.org renders on its profile page. But after the parallel API groups finish, it **overwrote** that value with `improving + supporting + leading + maverick` summed from `/v1/identifications` queries that filter by `current=true&current_taxon=true`. That sum undercounts because:

- `current_taxon=true` excludes every ID whose taxon has since gone inactive through taxonomy changes (swaps/merges) — for prolific identifiers this alone can drop thousands of IDs
- summing only the four named categories also drops IDs with no category

## Fix

- **Header count:** keep the authoritative `user.identifications_count` instead of overwriting it with the filtered category sum.
- **Identification Categories chart:** the donut's center total was that same filtered sum. The remainder (IDs of outdated taxa or without a category) now renders as a gray "Other" slice, so the chart total always equals the header count and the iNaturalist profile. The four category counts themselves are unchanged and still match iNat's identifications tab (the filters added deliberately in #4).

## Verification

Drove the page end-to-end in headless Chromium with a stubbed iNat API (user record `identifications_count: 507`, category queries returning 200/150/50/1, summing to 401):

- **Before (HEAD):** header shows **401** — reproduces the reported bug
- **After (this fix):** header shows **507**, and the chart legend reads Improving 200 (39%), Supporting 150 (30%), Leading 50 (10%), Maverick 1 (0%), Other 106 (21%) with 507 in the donut center

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tMCA8BodXe3e6QxVL9qhV