### PR TITLE
Make Identification Categories chart total match the profile ID count

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -562,6 +562,12 @@
           // category queries. Those queries filter by current_taxon=true and skip
           // uncategorized IDs, so the sum undercounts compared to the number shown
           // on the iNaturalist profile (user.identifications_count, set above).
+          // The gap (IDs of outdated taxa or without a category) goes into an
+          // "Other" slice so the chart total matches the profile count.
+          const categorizedIds = idData.improving + idData.supporting + idData.leading + idData.maverick;
+          const otherIds = Math.max(0, (user.identifications_count || 0) - categorizedIds);
+          if (otherIds > 0) idData.other = otherIds;
+
           lastIdData = idData;
           drawIdPieChart(idData);
 
@@ -669,7 +675,7 @@
       function drawIdPieChart(data) {
         const canvas = document.getElementById('idPieChart');
         const ctx = canvas.getContext('2d');
-        const total = data.improving + data.supporting + data.leading + data.maverick;
+        const total = data.improving + data.supporting + data.leading + data.maverick + (data.other || 0);
 
         if (total === 0) {
           ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -684,14 +690,16 @@
           improving: '#27ae60',
           supporting: '#3498db',
           leading: '#9b59b6',
-          maverick: '#e74c3c'
+          maverick: '#e74c3c',
+          other: '#95a5a6'
         };
 
         const labels = {
           improving: 'Improving',
           supporting: 'Supporting',
           leading: 'Leading',
-          maverick: 'Maverick'
+          maverick: 'Maverick',
+          other: 'Other'
         };
 
         // Draw pie chart


### PR DESCRIPTION
## Problem

Follow-up to #13. That PR fixed the header identification count, but the Identification Categories donut still showed the undercounted number: its center "total" was computed from the same four filtered category queries (`current=true&current_taxon=true`), which exclude IDs of taxa made inactive by taxonomy changes and IDs without a category.

## Fix

The remainder between `user.identifications_count` (what iNaturalist shows) and the sum of the four category counts now renders as a gray **"Other"** slice, so the donut's center total always equals the header count and the iNaturalist profile. The four category counts themselves are unchanged and still match iNat's identifications tab (the filters added deliberately in #4). The slice only appears when the gap is non-zero, and the dark-mode redraw includes it via `lastIdData`.

## Verification

Drove the page end-to-end in headless Chromium with a stubbed iNat API (user record `identifications_count: 507`, category queries returning 200/150/50/1, summing to 401): the donut center shows **507** and the legend reads Improving 200 (39%), Supporting 150 (30%), Leading 50 (10%), Maverick 1 (0%), Other 106 (21%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tMCA8BodXe3e6QxVL9qhV

---
_Generated by [Claude Code](https://claude.ai/code/session_016tMCA8BodXe3e6QxVL9qhV)_